### PR TITLE
Initialize the OutputCacheProvider when using a custom provider

### DIFF
--- a/DevTrends.MvcDonutCaching/CacheSettingsManager.cs
+++ b/DevTrends.MvcDonutCaching/CacheSettingsManager.cs
@@ -38,6 +38,16 @@ namespace DevTrends.MvcDonutCaching
 
             return _outputCacheSection.Providers[_outputCacheSection.DefaultProviderName].Type;
         }
+        
+        public ProviderSettings RetrieveOutputCacheProviderSettings()
+        {
+            if (_outputCacheSection.DefaultProviderName == AspnetInternalProviderName)
+            {
+                return null;
+            }
+
+            return _outputCacheSection.Providers[_outputCacheSection.DefaultProviderName];
+        }
 
         public OutputCacheProfile RetrieveOutputCacheProfile(string cacheProfileName)
         {

--- a/DevTrends.MvcDonutCaching/Interfaces/ICacheSettingsManager.cs
+++ b/DevTrends.MvcDonutCaching/Interfaces/ICacheSettingsManager.cs
@@ -1,10 +1,12 @@
-﻿using System.Web.Configuration;
+﻿using System.Configuration;
+using System.Web.Configuration;
 
 namespace DevTrends.MvcDonutCaching
 {
     public interface ICacheSettingsManager
     {
         string RetrieveOutputCacheProviderType();
+        ProviderSettings RetrieveOutputCacheProviderSettings();
         OutputCacheProfile RetrieveOutputCacheProfile(string cacheProfileName);
 
         bool IsCachingEnabledGlobally { get; }

--- a/DevTrends.MvcDonutCaching/OutputCache.cs
+++ b/DevTrends.MvcDonutCaching/OutputCache.cs
@@ -10,7 +10,8 @@ namespace DevTrends.MvcDonutCaching
 
         static OutputCache()
         {
-            var providerType = new CacheSettingsManager().RetrieveOutputCacheProviderType();
+            var providerSettings = new CacheSettingsManager().RetrieveOutputCacheProviderSettings();
+            var providerType = providerSettings.Type;
 
             if (providerType == null)
             {
@@ -26,7 +27,7 @@ namespace DevTrends.MvcDonutCaching
                 {
                     throw new ConfigurationErrorsException(string.Format("Unable to instantiate OutputCacheProvider of type '{0}'. Make sure you are specifying the full type name.", providerType), ex);
                 }
-
+                instance.Initialize(providerSettings.Name, providerSettings.Parameters);
             }
         }
 


### PR DESCRIPTION
Initialize() was never called when an instance of the OutputCacheProvider was created.
