### PR TITLE
fixed duplicate key exception

### DIFF
--- a/DevTrends.MvcDonutCaching/KeyGenerator.cs
+++ b/DevTrends.MvcDonutCaching/KeyGenerator.cs
@@ -106,10 +106,9 @@ namespace DevTrends.MvcDonutCaching
 
             if (!string.IsNullOrEmpty(cacheSettings.VaryByCustom))
             {
-                routeValues.Add(
-                    cacheSettings.VaryByCustom.ToLowerInvariant(),
-                    context.HttpContext.ApplicationInstance.GetVaryByCustomString(HttpContext.Current, cacheSettings.VaryByCustom)
-                );
+                // if there is an existing route value with the same key as varybycustom, we should overwrite it
+                routeValues[cacheSettings.VaryByCustom.ToLowerInvariant()] =
+                            context.HttpContext.ApplicationInstance.GetVaryByCustomString(HttpContext.Current, cacheSettings.VaryByCustom);
             }
 
             var key = _keyBuilder.BuildKey(controllerName, actionName, routeValues);


### PR DESCRIPTION
If the value of VaryByCustom is equal to a key that has already been
added to the route values, there will be a conflict.  Instead of add, it
now adds or replaces the given key.

<!---
@huboard:{"order":27.0,"milestone_order":27,"custom_state":""}
-->
