### PR TITLE
Allow a SkipByCustom string to be specified

### DIFF
--- a/DevTrends.MvcDonutCaching.Demo/Controllers/HomeController.cs
+++ b/DevTrends.MvcDonutCaching.Demo/Controllers/HomeController.cs
@@ -19,6 +19,12 @@ namespace DevTrends.MvcDonutCaching.Demo.Controllers
             return View(DateTime.Now);
         }
 
+        [DonutOutputCache(Duration = 24 * 3600, SkipByCustom = "preview")]
+        public ActionResult SimpleButCanSkip()
+        {
+            return View("Simple", DateTime.Now);
+        }
+
         [ChildActionOnly, DonutOutputCache(Duration = 60, Options = OutputCacheOptions.ReplaceDonutsInChildActions)]
         public ActionResult SimpleDonutOne()
         {

--- a/DevTrends.MvcDonutCaching.Demo/Global.asax.cs
+++ b/DevTrends.MvcDonutCaching.Demo/Global.asax.cs
@@ -24,6 +24,8 @@ namespace DevTrends.MvcDonutCaching.Demo
             BundleConfig.RegisterBundles(BundleTable.Bundles);
 
             Container = RegisterAutofac();
+
+            this.SetSkipByCustomStringDelegate(SkipByCustomString);
         }
 
         private static IContainer RegisterAutofac()
@@ -45,7 +47,7 @@ namespace DevTrends.MvcDonutCaching.Demo
 
             return container;
         }
-
+        
         public override string GetVaryByCustomString(HttpContext context, string custom)
         {
             if (string.IsNullOrWhiteSpace(custom))
@@ -71,6 +73,21 @@ namespace DevTrends.MvcDonutCaching.Demo
             }
 
             return base.GetVaryByCustomString(context, custom);
+        }
+
+        private static bool SkipByCustomString(HttpContextBase context, string custom)
+        {
+            switch (custom.ToLowerInvariant())
+            {
+                case "preview":
+                    if (context.Request.QueryString["preview"] == "1")
+                    {
+                        return true;
+                    }
+                    break;
+            }
+
+            return false;
         }
     }
 }

--- a/DevTrends.MvcDonutCaching/DonutOutputCacheAttribute.cs
+++ b/DevTrends.MvcDonutCaching/DonutOutputCacheAttribute.cs
@@ -78,6 +78,15 @@ namespace DevTrends.MvcDonutCaching
         }
 
         /// <summary>
+        /// Gets or sets the skip-by-custom value.
+        /// </summary>
+        public string SkipByCustom
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
         /// Gets or sets the cache profile name.
         /// </summary>
         public string CacheProfile
@@ -140,6 +149,15 @@ namespace DevTrends.MvcDonutCaching
         /// <param name="filterContext">The filter context.</param>
         public override void OnActionExecuting(ActionExecutingContext filterContext)
         {
+            if (SkipByCustom != null)
+            {
+                var skipByCustomDelegate =
+                    filterContext.HttpContext.Application[HttpApplicationExtensions.SkipByCustomApplicationStateKey] as
+                        Func<HttpContextBase, string, bool>;
+                if (skipByCustomDelegate != null && skipByCustomDelegate(filterContext.HttpContext, SkipByCustom))
+                    return;
+            }
+
             CacheSettings = BuildCacheSettings();
 
             var cacheKey = KeyGenerator.GenerateKey(filterContext, CacheSettings);

--- a/DevTrends.MvcDonutCaching/DonutOutputCacheAttribute.cs
+++ b/DevTrends.MvcDonutCaching/DonutOutputCacheAttribute.cs
@@ -243,7 +243,7 @@ namespace DevTrends.MvcDonutCaching
             });
         }
 
-        private bool SkipBecauseOfCustom(ActionExecutingContext filterContext)
+        private bool SkipBecauseOfCustom(ControllerContext filterContext)
         {
             if (SkipByCustom != null)
             {
@@ -272,7 +272,7 @@ namespace DevTrends.MvcDonutCaching
 
             // If we are in the context of a child action, the main action is responsible for setting
             // the right HTTP Cache headers for the final response.
-            if (!filterContext.IsChildAction)
+            if (!filterContext.IsChildAction && !SkipBecauseOfCustom(filterContext))
             {
                 CacheHeadersHelper.SetCacheHeaders(filterContext.HttpContext.Response, CacheSettings);
             }

--- a/DevTrends.MvcDonutCaching/HttpApplicationExtensions.cs
+++ b/DevTrends.MvcDonutCaching/HttpApplicationExtensions.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Web;
+
+namespace DevTrends.MvcDonutCaching
+{
+    public static class HttpApplicationExtensions
+    {
+        public const string SkipByCustomApplicationStateKey = "DonutCachingSkipByCustomKey";
+
+        public static void SetSkipByCustomStringDelegate(this HttpApplication application, Func<HttpContextBase, string, bool> func)
+        {
+            try
+            {
+                application.Application.Lock();
+                application.Application[SkipByCustomApplicationStateKey] = func;
+            }
+            finally
+            {
+                application.Application.UnLock();
+            }
+        }
+
+        public static Func<HttpContext, string, bool> GetSkipByCustomDelegate(this HttpApplication application)
+        {
+            return application.Application[SkipByCustomApplicationStateKey] as Func<HttpContext, string, bool>;
+        }
+    }
+}

--- a/DevTrends.MvcDonutCaching/MvcDonutCaching.csproj
+++ b/DevTrends.MvcDonutCaching/MvcDonutCaching.csproj
@@ -73,6 +73,7 @@
     <Compile Include="CacheSettingsManager.cs" />
     <Compile Include="EncryptingActionSettingsSerialiser.cs" />
     <Compile Include="Encryptor.cs" />
+    <Compile Include="HttpApplicationExtensions.cs" />
     <Compile Include="Interfaces\ICacheHeadersHelper.cs" />
     <Compile Include="Interfaces\IEncryptingActionSettingsSerialiser.cs" />
     <Compile Include="Interfaces\IEncryptor.cs" />

--- a/README.md
+++ b/README.md
@@ -64,6 +64,39 @@ You can also configure the output cache to use a custom provider:
 
 Note, that a custom provider is not included with this project but you can write one fairly easily by subclassing *System.Web.Caching.OutputCacheProvider*. A number of implementations are also available on the web.
 
+## Skip by custom ##
+Sometimes you want to allow the output caching to be bypassed entirely.  DonutCacheAttribute adds the ability to choose to do this dynamically, using a similar interface to the VaryByCustom functionality of the standard OutputCacheAttribute.
+
+E.g., in Global.asax.cs, 
+
+```csharp
+public class Application : HttpApplication
+{
+  protected void Application_Start()
+  {
+    this.SetSkipByCustomStringDelegate(SkipByCustomString); //extension method 
+  }
+  
+  private bool SkipByCustomString(HttpContextBase context, string custom)
+  {
+    if (custom == "SkipOnPreview")
+    {
+      if (context.Request.QueryString["cmspreview"] == "1")
+        return true;
+    }
+    
+    return false;
+  }
+}
+```
+then on your Action:
+
+```csharp
+[DonutOutputCache(SkipByCustom = "SkipOnPreview")]
+public ActionResult SomeAction(){ ... }
+```
+
+
 ## More Information ##
 
 A comprehensive guide to MVC Extensible Donut Caching is now available on the [DevTrends Blog](http://www.devtrends.co.uk/blog/donut-output-caching-in-asp.net-mvc-3).


### PR DESCRIPTION
Sometimes you want to allow the cache to be bypassed entirely.  For example if you are in draft mode and you want to preview your changes with a query string parameter or something.  

So I've written a SkipByCustom feature that works analogously to VaryByCustom but the delegate returns a bool which then ordains whether the thing should bypass the cache.

Not sure if you'll want to go for this or not.  If you do then I can add a little documentation.

Thanks for writing the library in the first place!
