### PR TITLE
Keep serialiser in sync with attribute.

### DIFF
--- a/DevTrends.MvcDonutCaching/DonutOutputCacheAttribute.cs
+++ b/DevTrends.MvcDonutCaching/DonutOutputCacheAttribute.cs
@@ -28,7 +28,7 @@ namespace DevTrends.MvcDonutCaching
             this(
                new KeyGenerator(keyBuilder),
                new OutputCacheManager(OutputCache.Instance, keyBuilder),
-               new DonutHoleFiller(new EncryptingActionSettingsSerialiser(new ActionSettingsSerialiser(), new Encryptor())),
+               new DonutHoleFiller(HtmlHelperExtensions.Serialiser),
                new CacheSettingsManager(),
                new CacheHeadersHelper()
         )


### PR DESCRIPTION
The getter on Serialiser can new up this serialiser if it's not set.
If the setting is changed in the app then it throws an exception for the mismatch